### PR TITLE
Fix infinite loop caused by bashupload.com being down

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -2,12 +2,16 @@
 set -eu -o pipefail -E
 
 echo "=============================================="
-
 screencapture test.jpg
 echo "Uploading screenshot..."
-until curl https://bashupload.com -T test.jpg; do
+i=10
+until curl https://bashupload.com -T test.jpg || [ $i == 0 ]; do
     echo "Error, sleeping"
     sleep 1
+    i=$((i-1))
 done
 
+if [ $i == 0 ]; then
+    echo "Error uploading screenshot"
+fi
 echo "=============================================="


### PR DESCRIPTION
Right now bashupload.com is down, causing the Github Actions script to infinitely loop, eating up the finite amount of minutes users are allotted each month. This change will allow the script to attempt the upload 10 times before moving on, wasting at most 10 seconds. 