### PR TITLE
Revert Xcode Version Upgrade

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -15,5 +15,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Sign
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.2.app
+          sudo xcode-select -s /Applications/Xcode_14.0.1.app
           ./sign.py


### PR DESCRIPTION
Hello,

I used this repo as a template for my CI repository today, and once I got everything setup, signing repeatedly froze at the following screenshot: 
![image](https://github.com/SignTools/SignTools-CI/assets/6644803/ba4ea38a-6461-467f-ba29-f3d3c5a6258a)

Logs attached:

[logs.txt](https://github.com/SignTools/SignTools-CI/files/12092815/logs.txt)

Reverting the Xcode version to 14.0.1 fixed this issue for me, and I'm able to sign successfully once I made that change. 
